### PR TITLE
验证器type属性改为数组类型，默认值GET/BODY都支持,验证请求时判断请求方式

### DIFF
--- a/src/Annotation/Mapping/Validate.php
+++ b/src/Annotation/Mapping/Validate.php
@@ -44,9 +44,9 @@ class Validate
     private $params = [];
 
     /**
-     * @var string
+     * @var array
      */
-    private $type = ValidateType::BODY;
+    private $type = [ValidateType::GET, ValidateType::BODY];
 
     /**
      * @var string
@@ -76,7 +76,7 @@ class Validate
             $this->params = $values['params'];
         }
         if (isset($values['type'])) {
-            $this->type = $values['type'];
+            $this->type = (array) $values['type'];
         }
         if (isset($values['message'])) {
             $this->message = $values['message'];
@@ -124,9 +124,9 @@ class Validate
     }
 
     /**
-     * @return string
+     * @return array
      */
-    public function getType(): string
+    public function getType()
     {
         return $this->type;
     }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -108,12 +108,14 @@ class Validator
 
             $validateType = $validate['type'];
             $isGetValidateType = false;
+
+            //判断该validator是否支持GET方式
             if (in_array(ValidateType::GET, $validateType)) {
                 $isGetValidateType = true;
             }
 
             // Get query params
-            if ($requestMethod == 'GET' && $isGetValidateType) {
+            if ($requestMethod == RequestMethod::GET && $isGetValidateType) {
                 $query = $this->validateValidator($query, $type, $validateName, $params, $validator, $fields,
                     $unfields);
                 continue;

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -85,11 +85,12 @@ class Validator
      * @param array $body
      * @param array $validates
      * @param array $query
+     * @param string $requestMethod
      *
      * @return array
      * @throws ValidatorException
      */
-    public function validateRequest(array $body, array $validates, array $query = []): array
+    public function validateRequest(array $body, array $validates, array $query = [], string $requestMethod=''): array
     {
         foreach ($validates as $validateName => $validate) {
             $validator = ValidatorRegister::getValidator($validateName);
@@ -106,9 +107,13 @@ class Validator
             $params   = $validate['params'] ?? [];
 
             $validateType = $validate['type'];
+            $isGetValidateType = false;
+            if (in_array(ValidateType::GET, $validateType)) {
+                $isGetValidateType = true;
+            }
 
             // Get query params
-            if ($validateType == ValidateType::GET) {
+            if ($requestMethod == 'GET' && $isGetValidateType) {
                 $query = $this->validateValidator($query, $type, $validateName, $params, $validator, $fields,
                     $unfields);
                 continue;


### PR DESCRIPTION
1.验证器的type属性默认值改为 数组 ['GET', 'BODY']，并修改该字段的获取方式以及注释
2.验证器验证请求时，判断是否支持GET请求，并按照请求方式来验证参数合法性